### PR TITLE
feat(deploy): add CORS headers for edgeone pages

### DIFF
--- a/edgeone.json
+++ b/edgeone.json
@@ -1,0 +1,21 @@
+{
+    "headers": [
+        {
+            "source": "/*",
+            "headers": [
+                {
+                    "key": "Access-Control-Allow-Origin",
+                    "value": "*"
+                },
+                {
+                    "key": "Access-Control-Allow-Methods",
+                    "value": "GET, OPTIONS"
+                },
+                {
+                    "key": "Access-Control-Allow-Headers",
+                    "value": "Content-Type"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Fix: deployment on EdgeOne Pages does not have CORS headers.